### PR TITLE
HP-137/ms: 브랜치 미처 푸시하지 못한 코드들 한꺼번에 PR

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ const App = () => {
 
   //NOTE 메인페이지에서 로그인 처리 작업 시 해당 로직 수정 필요합니다.
   useEffect(() => {
-    useLoginedStore.getState().setLoadined(null);
+    useLoginedStore.getState().setLogined(null);
     // TODO 새로고침 시 isLogined true로 변경 작업 필요
   }, []);
 

--- a/src/apis/member/category.api.ts
+++ b/src/apis/member/category.api.ts
@@ -7,7 +7,7 @@ import instance from '../instance/main';
 
 const getCategoryDetail = async () => {
   const response = await instance.get(`/api/categories`);
-  return response;
+  return response.data;
 };
 
 const categoryAPI = {

--- a/src/apis/member/product.api.ts
+++ b/src/apis/member/product.api.ts
@@ -16,23 +16,28 @@ const getProductList = async (categoryId: string, lastProductId?: number, size: 
   }
 
   const response = await instance.get(url);
-  return response;
+  return response.data;
 };
 
 const getProductDetail = async (productId: string) => {
   const response = await instance.get(`/api/products/${productId}`);
-  return response;
+  return response.data;
 };
 
 const getRelatedProducts = async () => {
   const response = await instance.get('/api/products/related');
-  return response;
+  return response.data;
 };
 
+const getBestProductList = async () => {
+  const response = await instance.get(`/api/products/best`);
+  return response.data;
+};
 const productAPI = {
   getProductList,
   getProductDetail,
   getRelatedProducts,
+  getBestProductList,
 };
 
 export default productAPI;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,8 +4,11 @@ import Footer from './Footer';
 import Header from './Header';
 import GlobalContainer from './modal/GlobalContainer';
 
+import { useAuthStateManager } from '@/hooks/useAuthStateManager';
+
 // TODO 각 페이지 확인 후 LayoutContainer 추가 여부 관련 수정 필요
 const Layout = () => {
+  useAuthStateManager();
   return (
     <div className='flex min-h-screen flex-col'>
       <Header />

--- a/src/components/carousel/Carousel.tsx
+++ b/src/components/carousel/Carousel.tsx
@@ -161,7 +161,6 @@ const Carousel = ({
         ? (availableWidth - gap * (visibleCount - 1)) / visibleCount
         : Math.max(200, (availableWidth - gap * (visibleCount - 1)) / visibleCount);
     } else {
-      // default mode
       if (visibleSlides) {
         calculatedSlideWidth = (containerWidth - gap * (visibleCount - 1)) / visibleCount;
       } else {
@@ -316,7 +315,6 @@ const Carousel = ({
 
       goTo(newIndex);
 
-      // Reset drag refs
       isDraggingRef.current = false;
       startXRef.current = null;
       startScrollXRef.current = null;

--- a/src/components/modal/WelcomeStepModal.tsx
+++ b/src/components/modal/WelcomeStepModal.tsx
@@ -3,7 +3,7 @@ import { useForm, type SubmitHandler } from 'react-hook-form';
 import { CgClose } from 'react-icons/cg';
 
 import StyledButton from '../button/StyledButton';
-import Input from '../input/BaseInput';
+/* import Input from '../input/BaseInput'; */
 
 import logoHappypill from '@/assets/icon/logo-happypill.svg';
 import Modal from '@/components/modal/ui/Modal';
@@ -18,6 +18,8 @@ import cn from '@/utils/classNames';
 interface NicknameInput {
   nickname: string;
 }
+
+//TODO: Input 태그 적용
 
 const WelcomeStepModal: React.FC = () => {
   const [currentStep, setCurrentStep] = useState(0);
@@ -93,7 +95,7 @@ const WelcomeStepModal: React.FC = () => {
             <form onSubmit={handleSubmit(onSubmit)}>
               {currentStep == 1 && (
                 <div>
-                  <Input
+                  <input
                     placeholder='닉네임을 입력해주세요'
                     className='mt-6 rounded-md border border-[#bbbbbb] p-3 px-5'
                     {...register('nickname', { required: '닉네임을 입력해주세요' })}

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,0 +1,17 @@
+export const CATEGORY_COLORS = [
+  'bg-red-400',
+  'bg-pink-400',
+  'bg-purple-400',
+  'bg-indigo-400',
+  'bg-blue-400',
+  'bg-cyan-400',
+  'bg-teal-400',
+  'bg-green-400',
+  'bg-yellow-400',
+  'bg-orange-400',
+  'bg-rose-400',
+  'bg-violet-400',
+  'bg-sky-400',
+  'bg-emerald-400',
+  'bg-amber-400',
+];

--- a/src/hooks/api/member/product.ts
+++ b/src/hooks/api/member/product.ts
@@ -8,7 +8,7 @@ import { queryKey } from '@/constants/queryKey';
 
 interface PageParam {
   categoryIndex: number;
-  lastProductId?: string | null;
+  lastProductId?: number | null;
 }
 
 /**
@@ -40,7 +40,10 @@ export const useGetProductList = (categories: Category[], activeCategoryId: stri
       while (currentCategoryIndex < filteredCategories.length) {
         const currentCategory = filteredCategories[currentCategoryIndex];
 
-        response = await productAPI.getProductList(currentCategory.categoryId, lastProductId);
+        response = await productAPI.getProductList(
+          currentCategory.categoryId,
+          lastProductId ?? undefined,
+        );
 
         // 상품이 있으면 해당 카테고리의 데이터 반환
         if (response.products && response.products.length > 0) {

--- a/src/hooks/api/member/user.ts
+++ b/src/hooks/api/member/user.ts
@@ -2,15 +2,13 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 
 import userAPI from '@/apis/member/user.api';
 import { queryKey } from '@/constants/queryKey';
-import useLoginedStore from '@/stores/loginedStore';
 
 export const useGetUserInfo = () => {
-  const { isLogined } = useLoginedStore();
   return useQuery({
     queryKey: queryKey.member.user.info,
     queryFn: () => userAPI.getUserInfo(),
-    enabled: !!isLogined,
     retry: false,
+    staleTime: 5 * 60 * 1000,
   });
 };
 

--- a/src/hooks/api/member/user.ts
+++ b/src/hooks/api/member/user.ts
@@ -2,11 +2,15 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 
 import userAPI from '@/apis/member/user.api';
 import { queryKey } from '@/constants/queryKey';
+import useLoginedStore from '@/stores/loginedStore';
 
 export const useGetUserInfo = () => {
+  const { isLogined } = useLoginedStore();
   return useQuery({
     queryKey: queryKey.member.user.info,
     queryFn: () => userAPI.getUserInfo(),
+    enabled: !!isLogined,
+    retry: false,
   });
 };
 

--- a/src/hooks/useAuthStateManager.ts
+++ b/src/hooks/useAuthStateManager.ts
@@ -11,23 +11,33 @@ import useLoginedStore from '@/stores/loginedStore';
  *
  */
 export const useAuthStateManager = () => {
-  const { data: userData, isLoading } = useGetUserInfo();
   const { setLogined } = useLoginedStore();
   const navigate = useNavigate();
+  const { data: userData, isLoading, error } = useGetUserInfo();
 
   useEffect(() => {
     if (isLoading) return;
 
+    // 에러가 있으면 로그아웃 상태
+    if (error) {
+      setLogined(null);
+      return;
+    }
+
+    // 유저 정보가 없으면 로그아웃 상태
     if (!userData) {
       setLogined(null);
-    } else if (userData && userData.nickname === null) {
+      return;
+    }
+    if (userData.nickname === null) {
+      // 닉네임이 없으면 온보딩 필요
       if (window.location.pathname !== '/') {
         navigate('/');
       }
     } else {
       setLogined(true);
     }
-  }, [userData, isLoading, setLogined]);
+  }, [userData, isLoading, setLogined, navigate, error]);
 
   return { userData, isLoading };
 };

--- a/src/hooks/useLocale.ts
+++ b/src/hooks/useLocale.ts
@@ -5,16 +5,16 @@ import type { LocaleType } from '@/types/common';
 import { appStorage } from '@/utils/appStorage';
 
 const useLocale = () => {
-  const [locale, setLocale] = useState<LocaleType>(() => ({
+  const [localeState, setLocaleState] = useState<LocaleType>(() => ({
     locale: (appStorage.getLanguage() ?? 'ko') as 'ko' | 'en',
   }));
 
   const changeLocale = (newLang: 'ko' | 'en') => {
     appStorage.setLanguage(newLang);
-    setLocale({ locale: newLang });
+    setLocaleState({ locale: newLang });
   };
 
-  return { locale, changeLocale };
+  return { locale: localeState.locale, changeLocale };
 };
 
 export default useLocale;

--- a/src/pages/main/components/molecules/Category.tsx
+++ b/src/pages/main/components/molecules/Category.tsx
@@ -37,7 +37,7 @@ const CategorySection: React.FC<CategorySectionProps> = ({
           key={firstCategory.categoryId}
           value='모든 상품'
           isActive={activeCategoryId === 'ALL'}
-          className='h-10 md:h-15'
+          className='h-10 w-48 md:h-15'
           onClick={() => onEventHandler(firstCategory, true)}
         />
         {categories?.map((category: Category) => {
@@ -47,7 +47,7 @@ const CategorySection: React.FC<CategorySectionProps> = ({
               icon={category.thumbnailUrl}
               value={category.name}
               isActive={activeCategoryId === category.categoryId}
-              className='h-10 md:h-15'
+              className='h-10 w-48 md:h-15'
               onClick={() => onEventHandler(category)}
             />
           );

--- a/src/pages/main/components/molecules/Category.tsx
+++ b/src/pages/main/components/molecules/Category.tsx
@@ -57,7 +57,7 @@ const CategorySection: React.FC<CategorySectionProps> = ({
   };
 
   return (
-    <div className='hide-scrollbar md:gap-x-auto mb-5 flex w-full gap-x-3 gap-y-4 overflow-x-scroll px-4 md:grid md:w-48 lg:px-0'>
+    <div className='hide-scrollbar mb-5 flex w-full gap-x-3 gap-y-4 overflow-x-auto px-4 md:w-48 md:flex-col md:gap-y-3 md:overflow-x-visible lg:px-0'>
       {renderContent()}
     </div>
   );

--- a/src/pages/main/components/organisms/Product.tsx
+++ b/src/pages/main/components/organisms/Product.tsx
@@ -31,7 +31,7 @@ const ProductSection: React.FC<ProductSectionProps> = ({
   isFetchingNextPage,
 }) => {
   return (
-    <Section title='product list' className='px-4'>
+    <Section title='product list'>
       <div className='mb-40 flex flex-col gap-x-[8vw] md:flex-row'>
         <CategorySection
           onEventHandler={onCategoryChange}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -98,6 +98,11 @@ body {
 }
 
 @layer utilities {
+  .hide-scrollbar {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+
   /* 10px 400 */
   .text-xxs-regular {
     @apply font-regular text-xxs leading-tight;


### PR DESCRIPTION
## PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 반영 브랜치
HP-137/ms  → dev

## 작업 사항
이전에 HP-137 브랜치로 작업한 내용 중 일부를 깜빡하고 푸시하지 못해,  
해당 변경사항들을 이번 PR에 모두 포함하여 올립니다.  죄송합니다.
검토 부탁드립니다.

- App.tsx: useLoginedStore 호출 시 getState().setLoaded → setLogined로 수정
- category 및 product API에서 response.Data → response.data로 수정
- WelcomeModal: PR되지 않은 Input 컴포넌트 대신 일반 <input> 태그로 임시 사용
- colors 상수 파일에 배경 색상(CATEGORY_COLORS) 임시 설정 추가
- useLocale 훅 내부 상태 변수명 변경 및 반환 구조 개선
- useGetProductList 훅에서 lastProductId 타입과 전달 방식 개선



## 체크리스트

- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (예: `cmd + opt + L`)

## 테스트 결과
- 테스트 결과 이상 없습니다.

