### PR TITLE
HP-160: 상품 상세페이지 기능 및 UI 구현

### DIFF
--- a/src/constants/locale.ts
+++ b/src/constants/locale.ts
@@ -1,3 +1,10 @@
+// common
+
+export const CURRENCY_UNIT = {
+  ko: '원',
+  en: 'KRW',
+};
+
 // main page
 
 export const MAIN_BANNER_DATA = [
@@ -96,6 +103,8 @@ export const PROMOTION_BANNER_DATA = [
   },
 ];
 
+// modal
+
 export const CREATE_WELCOME_STEPS = [
   {
     ko: {
@@ -166,5 +175,40 @@ export const CART_COMPLETE_MODAL = {
   },
   en: {
     message: 'Your item has been added to the cart.',
+  },
+};
+
+// product page
+
+export const PRODUCT_DELIVERY_BADGE = {
+  ko: {
+    prefix: '이 상품은',
+    highlight: '내일도착, 무료배송',
+  },
+  en: {
+    prefix: 'This product qualifies for',
+    highlight: 'Next-day Delivery & Free Shipping',
+  },
+};
+
+export const RELATED_PRODUCTS_SECTION = {
+  ko: {
+    title: '다른 고객이 함께 본 상품',
+    currencyUnit: '원',
+  },
+  en: {
+    title: 'Customers Also Viewed',
+    currencyUnit: 'KRW',
+  },
+};
+
+export const PRODUCT_TABS = {
+  ko: {
+    'product-info': '상세정보',
+    'product-detail': '제품상세',
+  },
+  en: {
+    'product-info': 'Product Info',
+    'product-detail': 'Details',
   },
 };

--- a/src/constants/locale.ts
+++ b/src/constants/locale.ts
@@ -212,3 +212,22 @@ export const PRODUCT_TABS = {
     'product-detail': 'Details',
   },
 };
+
+export const PRODUCT_DETAIL = {
+  ko: {
+    name: '제품명',
+    quantityDetails: '용량/수량',
+    company: '제조사',
+    usage: '섭취방법',
+    warningMessage: '주의사항',
+    description: '제품설명',
+  },
+  en: {
+    name: 'Product Name',
+    quantityDetails: 'Capacity/Quantity',
+    company: 'Manufacturer',
+    usage: 'How to Use',
+    warningMessage: 'Precautions',
+    description: 'Product Description',
+  },
+};

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -11,6 +11,13 @@ const common = {
     route: (productId: string) => `/product/${productId}`,
   },
   cart: '/cart',
+  purchase: {
+    direct: {
+      root: '/purchase/:productId',
+      route: (productId: string) => `/purchase/${productId}`,
+    },
+    cart: 'purchase/cart',
+  },
 };
 
 /** 유저 - 로그인 후 접근 */

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -6,6 +6,7 @@ const common = {
   login: '/login',
   logout: '/logout',
   oauthRedirect: '/oauth-redirect',
+  product: '/product/:productId',
   cart: '/cart',
 };
 

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -6,7 +6,10 @@ const common = {
   login: '/login',
   logout: '/logout',
   oauthRedirect: '/oauth-redirect',
-  product: '/product/:productId',
+  product: {
+    root: '/product/:productId',
+    route: (productId: string) => `/product/${productId}`,
+  },
   cart: '/cart',
 };
 

--- a/src/constants/subscription.ts
+++ b/src/constants/subscription.ts
@@ -1,0 +1,1 @@
+export const SUBSCRIPTION_MONTH_OPTIONS = [1, 3, 6];

--- a/src/hooks/api/member/product.ts
+++ b/src/hooks/api/member/product.ts
@@ -111,6 +111,7 @@ export const useGetProductDetail = (productId: string) => {
   return useQuery({
     queryKey: queryKey.member.product.detail(productId),
     queryFn: () => productAPI.getProductDetail(productId),
+    enabled: !!productId,
   });
 };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
 /* member */
 export { default as MainPage } from './main/index';
 export { default as Layout } from '../components/layout/Layout';
-
+export { default as ProductPage } from '@/pages/product/index';
 /* admin */
 export { default as AdminLayout } from '../components/layout/AdminLayout';
 

--- a/src/pages/main/components/molecules/ProductList.tsx
+++ b/src/pages/main/components/molecules/ProductList.tsx
@@ -3,6 +3,8 @@ import CardSkeleton from '../atoms/CardSkeleton';
 
 import type { ProductItem } from '@/types/products';
 
+import LoadingSpinner from '@/components/common/LoadingSpinner';
+
 interface ProductListProps {
   productBlock: ProductItem[];
   onLoadMore: () => void;
@@ -55,9 +57,7 @@ const ProductList: React.FC<ProductListProps> = ({
     <div className='w-full'>
       {renderContent()}
 
-      {isFetchingNextPage && (
-        <div className='mx-auto mt-40 h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600'></div>
-      )}
+      {isFetchingNextPage && <LoadingSpinner />}
       {!isFetchingNextPage && hasNext && (
         <div className='mt-40 text-center'>
           <button

--- a/src/pages/main/components/organisms/BestProduct.tsx
+++ b/src/pages/main/components/organisms/BestProduct.tsx
@@ -35,7 +35,6 @@ const BestProductSection: React.FC<BestProductProps> = ({ products, isLoading })
 
     return (
       <Carousel
-        variant='default'
         visibleSlides={{
           mobile: 1,
           tablet: 2,

--- a/src/pages/product/components/atoms/ProductDescription.tsx
+++ b/src/pages/product/components/atoms/ProductDescription.tsx
@@ -1,0 +1,5 @@
+const ProductDescription = ({ description }: { description: string }) => {
+  return <div className='text-[clamp(10px,1.5vw,14px)] text-gray-400'>{description}</div>;
+};
+
+export default ProductDescription;

--- a/src/pages/product/components/atoms/ProductHeader.tsx
+++ b/src/pages/product/components/atoms/ProductHeader.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import type { ProductDetail } from '@/types/products';
+
+import { PRODUCT_DELIVERY_BADGE } from '@/constants/locale';
+import useLocale from '@/hooks/useLocale';
+
+interface ProductHeaderProps {
+  product: ProductDetail;
+}
+
+const ProductHeader = ({ product }: ProductHeaderProps) => {
+  const { locale } = useLocale();
+  return (
+    <div className='border-b border-[#CECECE] pb-3'>
+      <div className='flex justify-between'>
+        <p className='font-regular text-[clamp(12px,1vw,14px)]'>{product?.company}</p>
+        <p className='text-primary text-[clamp(10px,1vw,14px)] font-medium'>
+          {PRODUCT_DELIVERY_BADGE[locale].prefix}
+          <strong className='ml-1'>{PRODUCT_DELIVERY_BADGE[locale].highlight}</strong>
+        </p>
+      </div>
+      <h2 className='mt-1 mb-2 text-[clamp(20px,2vw,34px)] font-bold'>{product?.name}</h2>
+      <p className='text-[clamp(10px,1.8vw,16px)] font-medium'> {product?.description}</p>
+    </div>
+  );
+};
+
+export default ProductHeader;

--- a/src/pages/product/components/atoms/ProductThumbnail.tsx
+++ b/src/pages/product/components/atoms/ProductThumbnail.tsx
@@ -1,0 +1,16 @@
+interface ProductThumbnailProps {
+  src: string;
+  alt: string;
+}
+
+const ProductThumbnail = ({ src, alt }: ProductThumbnailProps) => {
+  return (
+    <img
+      src={src}
+      className='h-[150px] w-full rounded-md border-[#E2E2E2] object-cover md:h-auto'
+      alt={alt}
+    />
+  );
+};
+
+export default ProductThumbnail;

--- a/src/pages/product/components/atoms/SubscriptionOptions.tsx
+++ b/src/pages/product/components/atoms/SubscriptionOptions.tsx
@@ -1,0 +1,32 @@
+import { type Dispatch } from 'react';
+
+import SubscriptionPlanButton from '@/components/button/SubscriptionPlanButton';
+import { SUBSCRIPTION_MONTH_OPTIONS } from '@/constants/subscription';
+
+interface SubscriptionOptionsProps {
+  subscriptionOption: number;
+  setSubscriptionOption: Dispatch<React.SetStateAction<number>>;
+}
+
+const SubscriptionOptions = ({
+  subscriptionOption,
+  setSubscriptionOption,
+}: SubscriptionOptionsProps) => {
+  return (
+    <div className='my-6'>
+      <p className='mb-2.5 text-[clamp(13px,1vw,16px)] font-semibold'>개월 옵션</p>
+      <div className='flex gap-x-2.5'>
+        {SUBSCRIPTION_MONTH_OPTIONS.map((month) => (
+          <SubscriptionPlanButton
+            key={month}
+            period={month}
+            isSelected={subscriptionOption === month}
+            onClick={() => setSubscriptionOption(month)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SubscriptionOptions;

--- a/src/pages/product/components/molecules/ProductInfoSection.tsx
+++ b/src/pages/product/components/molecules/ProductInfoSection.tsx
@@ -2,13 +2,16 @@ import type { Dispatch, SetStateAction } from 'react';
 
 import React from 'react';
 
+import ProductDescription from '../atoms/ProductDescription';
+import ProductHeader from '../atoms/ProductHeader';
+import ProductThumbnail from '../atoms/ProductThumbnail';
+import SubscriptionOptions from '../atoms/SubscriptionOptions';
+
 import type { ProductDetail } from '@/types/products';
 
 import StyledButton from '@/components/button/StyledButton';
-import SubscriptionPlanButton from '@/components/button/SubscriptionPlanButton';
 import PurchaseOption from '@/components/purchaseOption/PurchaseOption';
-import { CART_MODAL, PRODUCT_DELIVERY_BADGE } from '@/constants/locale';
-import { SUBSCRIPTION_MONTH_OPTIONS } from '@/constants/subscription';
+import { CART_MODAL } from '@/constants/locale';
 import useLocale from '@/hooks/useLocale';
 
 interface productInfoProps {
@@ -49,55 +52,30 @@ const ProductInfoSection: React.FC<productInfoProps> = ({
 
   return (
     <div className='max-width-container mx-auto grid w-full grid-cols-1 gap-x-5 md:grid-cols-2'>
-      <img
-        src={product?.thumbnailUrl}
-        className='h-[150px] w-full rounded-md border-[#E2E2E2] object-cover md:h-auto'
-        alt={`${product?.name} `}
-      />
+      <ProductThumbnail src={product?.thumbnailUrl} alt={`${product?.name}`} />
       <div className='pt-5 md:p-8'>
-        <div className='border-b border-[#CECECE] pb-3'>
-          <div className='flex justify-between'>
-            <p className='font-regular text-[clamp(12px,1vw,14px)]'>{product?.company}</p>
-            <p className='text-primary text-[clamp(10px,1vw,14px)] font-medium'>
-              {PRODUCT_DELIVERY_BADGE[locale].prefix}
-              <strong className='ml-1'>{PRODUCT_DELIVERY_BADGE[locale].highlight}</strong>
-            </p>
-          </div>
-          <h2 className='mt-1 mb-2 text-[clamp(20px,2vw,34px)] font-bold'>{product?.name}</h2>
-          <p className='text-[clamp(10px,1.8vw,16px)] font-medium'> {product?.description}</p>
-        </div>
-        <div>
-          <div className='my-6'>
-            <p className='mb-2.5 text-[clamp(13px,1vw,16px)] font-semibold'>개월 옵션</p>
-            <div className='flex gap-x-2.5'>
-              {SUBSCRIPTION_MONTH_OPTIONS.map((month) => (
-                <SubscriptionPlanButton
-                  key={month}
-                  period={month}
-                  isSelected={subscriptionOption === month}
-                  onClick={() => setSubscriptionOption(month)}
-                />
-              ))}
-            </div>
-          </div>
-          <div className='text-[clamp(10px,1.5vw,14px)] text-gray-400'>
-            {product?.briefDescription}
-          </div>
+        <ProductHeader product={product} />
 
-          <PurchaseOption className='p-0'>
-            <PurchaseOption.PriceSection
-              price={product?.price}
-              quantity={subscriptionOption}
-              priceLabel={CART_MODAL[locale].totalPriceLabel}
-              className='mt-[clamp(30px,5vw,90px)]'
-            />
-            <PurchaseOption.ButtonGroup>
-              {BUTTONS.map(({ key, ...buttonProps }) => (
-                <StyledButton key={key} {...buttonProps} />
-              ))}
-            </PurchaseOption.ButtonGroup>
-          </PurchaseOption>
-        </div>
+        <SubscriptionOptions
+          subscriptionOption={subscriptionOption}
+          setSubscriptionOption={setSubscriptionOption}
+        />
+
+        <ProductDescription description={product?.briefDescription} />
+
+        <PurchaseOption className='p-0'>
+          <PurchaseOption.PriceSection
+            price={product?.price}
+            quantity={subscriptionOption}
+            priceLabel={CART_MODAL[locale].totalPriceLabel}
+            className='mt-[clamp(30px,5vw,90px)]'
+          />
+          <PurchaseOption.ButtonGroup>
+            {BUTTONS.map(({ key, ...buttonProps }) => (
+              <StyledButton key={key} {...buttonProps} />
+            ))}
+          </PurchaseOption.ButtonGroup>
+        </PurchaseOption>
       </div>
     </div>
   );

--- a/src/pages/product/components/molecules/ProductInfoSection.tsx
+++ b/src/pages/product/components/molecules/ProductInfoSection.tsx
@@ -52,7 +52,7 @@ const ProductInfoSection: React.FC<productInfoProps> = ({
 
   return (
     <div className='max-width-container mx-auto grid w-full grid-cols-1 gap-x-5 md:grid-cols-2'>
-      <ProductThumbnail src={product?.thumbnailUrl} alt={`${product?.name}`} />
+      <ProductThumbnail src={product?.thumbnailUrl} alt={product?.name} />
       <div className='pt-5 md:p-8'>
         <ProductHeader product={product} />
 

--- a/src/pages/product/components/molecules/ProductInfoSection.tsx
+++ b/src/pages/product/components/molecules/ProductInfoSection.tsx
@@ -1,0 +1,106 @@
+import type { Dispatch, SetStateAction } from 'react';
+
+import React from 'react';
+
+import type { ProductDetail } from '@/types/products';
+
+import StyledButton from '@/components/button/StyledButton';
+import SubscriptionPlanButton from '@/components/button/SubscriptionPlanButton';
+import PurchaseOption from '@/components/purchaseOption/PurchaseOption';
+import { CART_MODAL, PRODUCT_DELIVERY_BADGE } from '@/constants/locale';
+import { SUBSCRIPTION_MONTH_OPTIONS } from '@/constants/subscription';
+import useLocale from '@/hooks/useLocale';
+
+interface productInfoProps {
+  product: ProductDetail;
+  subscriptionOption: number;
+  setSubscriptionOption: Dispatch<SetStateAction<number>>;
+  onAddToCart: () => void;
+  onCheckout: (productId: string) => void;
+}
+
+const ProductInfoSection: React.FC<productInfoProps> = ({
+  product,
+  subscriptionOption,
+  setSubscriptionOption,
+  onAddToCart,
+  onCheckout,
+}) => {
+  const { locale } = useLocale();
+
+  const BUTTONS = [
+    {
+      key: 'addToCart',
+      children: CART_MODAL[locale].addToCart,
+      onClick: onAddToCart,
+      variant: 'border',
+      size: 'XL',
+      className: 'h-[clamp(35px,5vw,50px)] rounded-sm bg-white text-[clamp(14px,2vw,18px)]',
+    },
+    {
+      key: 'buyNow',
+      children: CART_MODAL[locale].buyNow,
+      onClick: () => onCheckout(product.productId),
+      variant: 'green',
+      size: 'XL',
+      className: 'h-[clamp(35px,5vw,50px)] rounded-sm text-[clamp(14px,2vw,18px)]',
+    },
+  ] as const;
+
+  return (
+    <div className='max-width-container mx-auto grid w-full grid-cols-1 gap-x-5 md:grid-cols-2'>
+      <img
+        src={product?.thumbnailUrl}
+        className='h-[150px] w-full rounded-md border-[#E2E2E2] object-cover md:h-auto'
+        alt={`${product?.name} `}
+      />
+      <div className='pt-5 md:p-8'>
+        <div className='border-b border-[#CECECE] pb-3'>
+          <div className='flex justify-between'>
+            <p className='font-regular text-[clamp(12px,1vw,14px)]'>{product?.company}</p>
+            <p className='text-primary text-[clamp(10px,1vw,14px)] font-medium'>
+              {PRODUCT_DELIVERY_BADGE[locale].prefix}
+              <strong className='ml-1'>{PRODUCT_DELIVERY_BADGE[locale].highlight}</strong>
+            </p>
+          </div>
+          <h2 className='mt-1 mb-2 text-[clamp(20px,2vw,34px)] font-bold'>{product?.name}</h2>
+          <p className='text-[clamp(10px,1.8vw,16px)] font-medium'> {product?.description}</p>
+        </div>
+        <div>
+          <div className='my-6'>
+            <p className='mb-2.5 text-[clamp(13px,1vw,16px)] font-semibold'>개월 옵션</p>
+            <div className='flex gap-x-2.5'>
+              {SUBSCRIPTION_MONTH_OPTIONS.map((month) => (
+                <SubscriptionPlanButton
+                  key={month}
+                  period={month}
+                  isSelected={subscriptionOption === month}
+                  onClick={() => setSubscriptionOption(month)}
+                />
+              ))}
+            </div>
+          </div>
+          <div className='text-[clamp(10px,1.5vw,14px)] text-gray-400'>
+            {product?.briefDescription}
+          </div>
+
+          <PurchaseOption className='p-0'>
+            <PurchaseOption.PriceSection
+              price={product?.price}
+              quantity={subscriptionOption}
+              priceLabel={CART_MODAL[locale].totalPriceLabel}
+              className='mt-[clamp(30px,5vw,90px)]'
+            />
+            <PurchaseOption.ButtonGroup>
+              {BUTTONS.map(({ key, ...buttonProps }) => (
+                <StyledButton key={key} {...buttonProps} />
+              ))}
+            </PurchaseOption.ButtonGroup>
+          </PurchaseOption>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProductInfoSection;

--- a/src/pages/product/components/molecules/RelatedProductsCarousel.tsx
+++ b/src/pages/product/components/molecules/RelatedProductsCarousel.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import Carousel from '@/components/carousel/Carousel';
+import { RELATED_PRODUCTS_SECTION } from '@/constants/locale';
+import useLocale from '@/hooks/useLocale';
+
+interface RelatedProductsCarouselProps {
+  products: {
+    productId: string;
+    thumbnail: string;
+    price: number;
+  }[];
+  onClickProduct: (productId: string) => void;
+}
+
+const RelatedProductsCarousel: React.FC<RelatedProductsCarouselProps> = ({
+  products,
+  onClickProduct,
+}) => {
+  const { locale } = useLocale();
+  return (
+    <div className='mt-[100px] max-w-[1280px]'>
+      <h3 className='mb-5 text-[clamp(17px,2vw,22px)] font-bold'>
+        {RELATED_PRODUCTS_SECTION[locale].title}
+      </h3>
+      <div className='relative mx-auto'>
+        <Carousel variant='peek'>
+          <Carousel.ItemList>
+            {products.map((item, idx) => (
+              <Carousel.Item key={idx} onClick={() => onClickProduct(item.productId)}>
+                <div className='flex flex-col items-center gap-y-2'>
+                  <img
+                    className='h-[clamp(110px,10vw,200px)] w-[clamp(110px,10vw,200px)] overflow-hidden rounded-xl object-cover'
+                    draggable={false}
+                    src={item.thumbnail}
+                    alt='상품 이미지'
+                  />
+                  <p className='text-[clamp(12px,1vw,14px)] font-bold'>
+                    {item.price.toLocaleString()}원
+                  </p>
+                </div>
+              </Carousel.Item>
+            ))}
+          </Carousel.ItemList>
+          <Carousel.Navigation />
+        </Carousel>
+      </div>
+    </div>
+  );
+};
+
+export default RelatedProductsCarousel;

--- a/src/pages/product/components/molecules/StickySummary.tsx
+++ b/src/pages/product/components/molecules/StickySummary.tsx
@@ -1,0 +1,88 @@
+import type { Dispatch, SetStateAction } from 'react';
+
+import StyledButton from '@/components/button/StyledButton';
+import PurchaseOption from '@/components/purchaseOption/PurchaseOption';
+import Select from '@/components/select/Select';
+import { CART_MODAL } from '@/constants/locale';
+import { SUBSCRIPTION_MONTH_OPTIONS } from '@/constants/subscription';
+import useLocale from '@/hooks/useLocale';
+
+interface StickySummaryProps {
+  price: number;
+  subscriptionOption: number;
+  setSubscriptionOption: Dispatch<SetStateAction<number>>;
+  onAddToCart: () => void;
+  onCheckout: () => void;
+}
+
+const StickySummary: React.FC<StickySummaryProps> = ({
+  price,
+  subscriptionOption,
+  setSubscriptionOption,
+  onAddToCart,
+  onCheckout,
+}) => {
+  const { locale } = useLocale();
+
+  const BUTTONS = [
+    { key: 'addToCart', variant: 'border', onClick: onAddToCart },
+    { key: 'buyNow', variant: 'green', onClick: onCheckout },
+  ] as const;
+
+  const handleChange = (value: string | number) => {
+    setSubscriptionOption(Number(value));
+  };
+
+  return (
+    <div className='max-w-[400px]'>
+      <div className='left-0 mt-10 hidden h-fit rounded-md bg-white lg:sticky lg:top-[250px] lg:block'>
+        <PurchaseOption>
+          <PurchaseOption.Header>
+            <PurchaseOption.Title>{CART_MODAL[locale].title}</PurchaseOption.Title>
+            <Select value={subscriptionOption} onChange={handleChange}>
+              <Select.Trigger
+                className='border-1 border-[#dedede]'
+                suffix={CART_MODAL[locale].subscriptionLabel}
+              />
+              <Select.Content className='border-1 border-[#DEDEDE]'>
+                <Select.Group className='grid'>
+                  {SUBSCRIPTION_MONTH_OPTIONS.map((month) => (
+                    <Select.Item
+                      key={month}
+                      value={month}
+                      className='text-[clamp(13px,2vw,16px)] hover:bg-gray-100'
+                    >
+                      {month}
+                      {CART_MODAL[locale].subscriptionLabel}
+                    </Select.Item>
+                  ))}
+                </Select.Group>
+              </Select.Content>
+            </Select>
+          </PurchaseOption.Header>
+          <PurchaseOption.PriceSection
+            price={price}
+            quantity={subscriptionOption}
+            priceLabel={CART_MODAL[locale].totalPriceLabel}
+            className='mt-40'
+          />
+          <PurchaseOption.ButtonGroup>
+            {BUTTONS.map(({ key, variant, onClick }) => (
+              <StyledButton
+                key={key}
+                variant={variant}
+                size='XL'
+                className='h-[clamp(35px,5vw,50px)] rounded-sm text-[clamp(14px,2vw,18px)]'
+                onClick={onClick}
+              >
+                {CART_MODAL[locale][key]}
+              </StyledButton>
+            ))}
+          </PurchaseOption.ButtonGroup>
+        </PurchaseOption>
+      </div>
+    </div>
+  );
+};
+
+export default StickySummary;

--- a/src/pages/product/components/organisms/MobilePurchasePanel.tsx
+++ b/src/pages/product/components/organisms/MobilePurchasePanel.tsx
@@ -7,7 +7,7 @@ import { CART_MODAL } from '@/constants/locale';
 import { SUBSCRIPTION_MONTH_OPTIONS } from '@/constants/subscription';
 import useLocale from '@/hooks/useLocale';
 
-interface MobilePurchasePanel {
+interface MobilePurchasePanelProps {
   price: number;
   subscriptionOption: number;
   setSubscriptionOption: Dispatch<SetStateAction<number>>;
@@ -21,7 +21,7 @@ const MobilePurchasePanel = ({
   setSubscriptionOption,
   onAddToCart,
   onCheckout,
-}: MobilePurchasePanel) => {
+}: MobilePurchasePanelProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const { locale } = useLocale();
   const cartLocale = CART_MODAL[locale];

--- a/src/pages/product/components/organisms/MobilePurchasePanel.tsx
+++ b/src/pages/product/components/organisms/MobilePurchasePanel.tsx
@@ -1,0 +1,119 @@
+import { useState, type Dispatch, type SetStateAction } from 'react';
+
+import StyledButton from '@/components/button/StyledButton';
+import PurchaseOption from '@/components/purchaseOption/PurchaseOption';
+import Select from '@/components/select/Select';
+import { CART_MODAL } from '@/constants/locale';
+import { SUBSCRIPTION_MONTH_OPTIONS } from '@/constants/subscription';
+import useLocale from '@/hooks/useLocale';
+
+interface MobilePurchasePanel {
+  price: number;
+  subscriptionOption: number;
+  setSubscriptionOption: Dispatch<SetStateAction<number>>;
+  onAddToCart: () => void;
+  onCheckout: () => void;
+}
+
+const MobilePurchasePanel = ({
+  price,
+  subscriptionOption,
+  setSubscriptionOption,
+  onAddToCart,
+  onCheckout,
+}: MobilePurchasePanel) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const { locale } = useLocale();
+  const cartLocale = CART_MODAL[locale];
+  const handleAddToCartClick = () => {
+    onAddToCart();
+    setIsExpanded(false);
+  };
+  const handleChange = (value: string | number) => {
+    setSubscriptionOption(Number(value));
+  };
+  const BUTTONS = [
+    {
+      key: 'addToCart',
+      children: cartLocale.addToCart,
+      onClick: handleAddToCartClick,
+      variant: 'border',
+      size: 'XL',
+      className: 'text-s-medium h-[clamp(35px,5vw,50px)] flex-1 rounded-sm',
+    },
+    {
+      key: 'buyNow',
+      children: cartLocale.buyNow,
+      onClick: onCheckout,
+      variant: 'green',
+      size: 'XL',
+      className: 'text-s-medium h-[clamp(35px,5vw,50px)] flex-1 rounded-sm',
+    },
+  ] as const;
+
+  return (
+    <div className='pointer-events-none fixed top-0 left-0 z-11 h-[100vh] w-full justify-center lg:hidden'>
+      {isExpanded && (
+        <div
+          className='pointer-events-auto absolute inset-0 top-0 left-0 bg-black/25'
+          onClick={() => setIsExpanded(false)}
+        />
+      )}
+      <div className='pointer-events-auto absolute bottom-0 left-0 w-full bg-white'>
+        {isExpanded && (
+          <PurchaseOption>
+            <PurchaseOption.Header>
+              <PurchaseOption.Title>{CART_MODAL[locale].title}</PurchaseOption.Title>
+              <Select value={subscriptionOption} onChange={handleChange}>
+                <Select.Trigger
+                  className='border-1 border-[#dedede]'
+                  suffix={CART_MODAL[locale].subscriptionLabel}
+                />
+                <Select.Content className='border-1 border-[#DEDEDE]'>
+                  <Select.Group className='grid'>
+                    {SUBSCRIPTION_MONTH_OPTIONS.map((month) => (
+                      <Select.Item
+                        key={month}
+                        value={month}
+                        className='text-[clamp(13px,2vw,16px)] hover:bg-gray-100'
+                      >
+                        {month}
+                        {CART_MODAL[locale].subscriptionLabel}
+                      </Select.Item>
+                    ))}
+                  </Select.Group>
+                </Select.Content>
+              </Select>
+            </PurchaseOption.Header>
+            <PurchaseOption.PriceSection
+              price={price}
+              quantity={subscriptionOption}
+              priceLabel={CART_MODAL[locale].totalPriceLabel}
+              className='mt-40'
+            />
+          </PurchaseOption>
+        )}
+        <div className='flex justify-center border-t-1 border-[#eee] px-[30px] py-4'>
+          {!isExpanded ? (
+            <StyledButton
+              variant='green'
+              size='XL'
+              className='text-s-medium h-[clamp(35px,5vw,50px)] flex-1 rounded-sm'
+              onClick={() => setIsExpanded(true)}
+            >
+              구매하기
+            </StyledButton>
+          ) : (
+            <div className='flex w-full gap-x-3'>
+              {BUTTONS.map(({ key, ...buttonProps }) => (
+                <StyledButton key={key} {...buttonProps} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MobilePurchasePanel;

--- a/src/pages/product/components/organisms/ProductDetailTabs.tsx
+++ b/src/pages/product/components/organisms/ProductDetailTabs.tsx
@@ -38,7 +38,6 @@ const ProductDetailTabs = ({
     { label: PRODUCT_DETAIL[currentLocale].description, value: product.description },
   ] as const;
 
-  console.log('product', product);
   const { locale } = useLocale();
   const { isFixed, triggerRef } = useScrollTrigger();
   const TAB_KEYS = ['product-info', 'product-detail'] as const;

--- a/src/pages/product/components/organisms/ProductDetailTabs.tsx
+++ b/src/pages/product/components/organisms/ProductDetailTabs.tsx
@@ -1,0 +1,128 @@
+import { type Dispatch, type SetStateAction } from 'react';
+
+import MobilePurchasePanel from './MobilePurchasePanel';
+import StickySummary from '../molecules/StickySummary';
+
+import type { ProductDetail } from '@/types/products';
+
+import LoadingSpinner from '@/components/common/LoadingSpinner';
+import Tabs from '@/components/tabs/Tabs';
+import { PRODUCT_DETAIL, PRODUCT_TABS } from '@/constants/locale';
+import useLocale from '@/hooks/useLocale';
+import useScrollTrigger from '@/hooks/useScrollTrigger';
+import cn from '@/utils/classNames';
+
+interface ProductDetailTabsProps {
+  product: ProductDetail;
+  subscriptionOption: number;
+  setSubscriptionOption: Dispatch<SetStateAction<number>>;
+  onAddToCart: () => void;
+  onCheckout: (productId: string) => void;
+}
+
+const ProductDetailTabs = ({
+  product,
+  subscriptionOption,
+  setSubscriptionOption,
+  onAddToCart,
+  onCheckout,
+}: ProductDetailTabsProps) => {
+  const { locale: currentLocale } = useLocale();
+
+  const PRODUCT_DETAIL_FIELDS = [
+    { label: PRODUCT_DETAIL[currentLocale].name, value: product.name },
+    { label: PRODUCT_DETAIL[currentLocale].quantityDetails, value: product.quantityDetails },
+    { label: PRODUCT_DETAIL[currentLocale].company, value: product.company },
+    { label: PRODUCT_DETAIL[currentLocale].usage, value: product.usage },
+    { label: PRODUCT_DETAIL[currentLocale].warningMessage, value: product.warningMessage },
+    { label: PRODUCT_DETAIL[currentLocale].description, value: product.description },
+  ] as const;
+
+  console.log('product', product);
+  const { locale } = useLocale();
+  const { isFixed, triggerRef } = useScrollTrigger();
+  const TAB_KEYS = ['product-info', 'product-detail'] as const;
+  return (
+    <div className='mt-[clamp(60px,10vw,80px)]'>
+      <div ref={triggerRef} className='top-[100px]' />
+      <Tabs defaultValue='product-info'>
+        <Tabs.List
+          className={cn(
+            'border-primary-text bg-baseBg relative gap-x-0 rounded-none border-b',
+            isFixed && 'top-[100px] z-10 w-full md:fixed',
+          )}
+        >
+          {TAB_KEYS.map((value) => (
+            <Tabs.Item
+              key={value}
+              value={value}
+              className={cn(
+                'flex h-[clamp(40px,5vw,60px)] w-[clamp(150px,20vw,250px)] items-center justify-center rounded-xl rounded-b-none py-2 text-[clamp(13px,2vw,18px)] font-bold',
+                isFixed && 'rounded-none',
+              )}
+              activeClassName='bg-primary-text text-white'
+            >
+              {PRODUCT_TABS[locale][value]}
+            </Tabs.Item>
+          ))}
+        </Tabs.List>
+
+        <div className='relative grid grid-cols-1 gap-x-[clamp(20px,5vw,150px)] lg:grid-cols-[1.5fr_1fr]'>
+          <Tabs.Panel value='product-info'>
+            <div className='mt-[clamp(5px,5vw,60px)]'>
+              <img
+                className='mx-auto w-full'
+                src='https://esther2023.cdn-nhncommerce.com/data/editor/goods/250527/d1d0de88c6d771ab23f5282c31c64759_161951.jpg'
+                alt='이미지 설명'
+              />
+            </div>
+          </Tabs.Panel>
+          <Tabs.Panel value='product-detail'>
+            <div className='mt-[clamp(14px,20vw,60px)]'>
+              {product ? (
+                <table className='w-full'>
+                  <colgroup>
+                    <col width={'20%'} />
+                    <col width={'80%'} />
+                  </colgroup>
+                  <tbody>
+                    {PRODUCT_DETAIL_FIELDS.map(({ label, value }) => {
+                      return (
+                        <tr key={value} className='border-b-[1px] border-[#DCDCDC]'>
+                          <th className='bg-[#f1efef] px-5 py-3 text-left text-[clamp(10px,1vw,12px)] text-[#7C7C7C]'>
+                            {label}
+                          </th>
+                          <td className='bg-white px-5 py-3 text-left text-[clamp(10px,1vw,12px)]'>
+                            {value}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              ) : (
+                <LoadingSpinner className='h-[200px] w-full' />
+              )}
+            </div>
+          </Tabs.Panel>
+          <StickySummary
+            price={product.price}
+            subscriptionOption={subscriptionOption}
+            setSubscriptionOption={setSubscriptionOption}
+            onAddToCart={onAddToCart}
+            onCheckout={() => onCheckout(product?.productId)}
+          />
+          <MobilePurchasePanel
+            price={product.price}
+            subscriptionOption={subscriptionOption}
+            setSubscriptionOption={setSubscriptionOption}
+            onAddToCart={onAddToCart}
+            onCheckout={() => onCheckout(product?.productId)}
+          />
+        </div>
+      </Tabs>
+    </div>
+  );
+};
+
+export default ProductDetailTabs;

--- a/src/pages/product/index.tsx
+++ b/src/pages/product/index.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import ProductInfoSection from './components/molecules/ProductInfoSection';
+import RelatedProductsCarousel from './components/molecules/RelatedProductsCarousel';
+import useModal from '../../hooks/useModal';
+import { cartStorage } from '../../utils/cartStorage';
+import ProductDetailTabs from './components/organisms/ProductDetailTabs';
+
+import LoadingSpinner from '@/components/common/LoadingSpinner';
+import { useGetProductDetail, useGetRelatedProducts } from '@/hooks/api/member/product';
+
+const ProductPage: React.FC = () => {
+  const { productId } = useParams();
+  const [subscriptionOption, setSubscriptionOption] = useState(1);
+  console.log('script', subscriptionOption);
+  /*  const [relatedProducts, setRelatedProducts] = useState<RelatedProduct[]>([]) */
+  const navigate = useNavigate();
+  const { openModal } = useModal();
+
+  const { data: productData, isLoading: isLoadingProductDetail } = useGetProductDetail(
+    productId ?? '',
+  );
+  const { data: bestProductData, isLoading: isLoadingRelatedProducts } = useGetRelatedProducts();
+
+  const handleProductClick = (productId: string) => {
+    navigate(`/product/${productId}`);
+  };
+
+  // 장바구니(스토리지)에 담는 함수
+  const handleAddToCart = () => {
+    if (!productData) return;
+
+    const item = {
+      productId: productData.productId,
+      name: productData.name,
+      price: productData.price,
+      briefDescription: productData.briefDescription,
+      thumbnailUrl: productData.thumbnailUrl,
+      period: subscriptionOption,
+    };
+
+    cartStorage.save(item);
+    openModal({ type: 'cartAddSuccess' });
+  };
+
+  const handlePurchase = (productId: string) => {
+    navigate(`/purchase/${productId}`);
+  };
+
+  useEffect(() => {
+    //새로고침 시 브라우저의 스크롤 유지 기능을 방지하여 맨 위로 올림
+    if (!productData) return;
+    requestAnimationFrame(() => {
+      window.scrollTo({ top: 0 });
+    });
+  }, [productData?.productId]);
+
+  if (isLoadingProductDetail || isLoadingRelatedProducts || !productData) {
+    return (
+      <div className='flex h-[150vh] w-full items-center justify-center'>
+        <LoadingSpinner />
+      </div>
+    );
+  }
+  return (
+    <div className='max-width-container mx-auto w-full px-[30px] pt-[clamp(120px,15vw,200px)] pb-[40px]'>
+      <ProductInfoSection
+        product={productData}
+        subscriptionOption={subscriptionOption}
+        setSubscriptionOption={setSubscriptionOption}
+        onAddToCart={handleAddToCart}
+        onCheckout={handlePurchase}
+      />
+
+      <ProductDetailTabs
+        product={productData}
+        subscriptionOption={subscriptionOption}
+        setSubscriptionOption={setSubscriptionOption}
+        onAddToCart={handleAddToCart}
+        onCheckout={handlePurchase}
+      />
+      <RelatedProductsCarousel products={bestProductData} onClickProduct={handleProductClick} />
+    </div>
+  );
+};
+export default ProductPage;

--- a/src/pages/product/index.tsx
+++ b/src/pages/product/index.tsx
@@ -8,13 +8,13 @@ import { cartStorage } from '../../utils/cartStorage';
 import ProductDetailTabs from './components/organisms/ProductDetailTabs';
 
 import LoadingSpinner from '@/components/common/LoadingSpinner';
+import { routePath } from '@/constants/path';
 import { useGetProductDetail, useGetRelatedProducts } from '@/hooks/api/member/product';
 
 const ProductPage: React.FC = () => {
   const { productId } = useParams();
   const [subscriptionOption, setSubscriptionOption] = useState(1);
-  console.log('script', subscriptionOption);
-  /*  const [relatedProducts, setRelatedProducts] = useState<RelatedProduct[]>([]) */
+
   const navigate = useNavigate();
   const { openModal } = useModal();
 
@@ -24,7 +24,7 @@ const ProductPage: React.FC = () => {
   const { data: bestProductData, isLoading: isLoadingRelatedProducts } = useGetRelatedProducts();
 
   const handleProductClick = (productId: string) => {
-    navigate(`/product/${productId}`);
+    navigate(routePath.common.product.route(productId));
   };
 
   // 장바구니(스토리지)에 담는 함수
@@ -45,7 +45,7 @@ const ProductPage: React.FC = () => {
   };
 
   const handlePurchase = (productId: string) => {
-    navigate(`/purchase/${productId}`);
+    navigate(routePath.common.purchase.direct.route(productId));
   };
 
   useEffect(() => {

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -22,7 +22,7 @@ const router = createBrowserRouter([
         element: <LoginPage />,
       },
       { path: routePath.common.oauthRedirect, element: <OauthRedirectPage /> },
-      { path: routePath.common.product, element: <ProductPage /> },
+      { path: routePath.common.product.root, element: <ProductPage /> },
     ],
   },
   {

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,7 +1,14 @@
 import { createBrowserRouter } from 'react-router-dom';
 
-import { routePath } from './constants/path';
-import { AdminLayout, Layout, LoginPage, MainPage, OauthRedirectPage } from './pages/index';
+import { routePath } from '@/constants/path';
+import {
+  AdminLayout,
+  Layout,
+  LoginPage,
+  MainPage,
+  OauthRedirectPage,
+  ProductPage,
+} from '@/pages/index';
 
 const router = createBrowserRouter([
   {
@@ -15,6 +22,7 @@ const router = createBrowserRouter([
         element: <LoginPage />,
       },
       { path: routePath.common.oauthRedirect, element: <OauthRedirectPage /> },
+      { path: routePath.common.proudct, element: <ProductPage /> },
     ],
   },
   {

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -22,7 +22,7 @@ const router = createBrowserRouter([
         element: <LoginPage />,
       },
       { path: routePath.common.oauthRedirect, element: <OauthRedirectPage /> },
-      { path: routePath.common.proudct, element: <ProductPage /> },
+      { path: routePath.common.product, element: <ProductPage /> },
     ],
   },
   {


### PR DESCRIPTION
## PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 반영 브랜치

HP-160/ms → dev

## 작업 사항
### 상품 상세 페이지 구현
ProductPage 경로 추가 및 routePath.common에 등록
- 상품 상세 페이지 전체 UI 및 기능 구현
- 상품 정보 영역 → ProductInfoSection 컴포넌트 분리
- 관련 상품 캐러셀 → RelatedProductsCarousel 컴포넌트 분리
- 구매 옵션 요약 영역 → StickySummary 컴포넌트 분리
- 모바일 전용 구매하기 버튼 → MobilePurchasePanel 컴포넌트 구현

상세 탭 UI 구현 및 관련 컴포넌트 연동

### 공통 리소스 정리
상품 상세 관련 상수(PRODUCT_DETAIL, SUBSCRIPTION_MONTH_OPTIONS) 분리
공통 로딩 스피너 → LoadingSpinner 컴포넌트로 분리 및 적용
useGetProductDetail에 productId 존재 여부 기반 enabled 옵션 추가

### 기타
route 오타 수정
불필요한 코드 제거 및 정리


### 미팅 건의 사항
- constants/locale 내부 코드가 페이지가 늘어나면서 양이 많아 질 것으로 보여서 파일별로 분리하는게 좋아보입니다!

## 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (예: `cmd + opt + L`)

## 테스트 결과
- 테스트 결과 이상 없습니다.
 
