### PR TITLE
HP-167: header 사이즈 조절 및 언어 기능 추가

### DIFF
--- a/src/components/container/LayoutContainer.tsx
+++ b/src/components/container/LayoutContainer.tsx
@@ -1,3 +1,4 @@
+import { HEADER_HEIGHT_SIZE } from '@/constants/common';
 import { cn } from '@/utils/classNames';
 
 interface LayoutContainerProps {
@@ -17,10 +18,8 @@ const LayoutContainer = ({
 }: LayoutContainerProps) => {
   return (
     <main
-      className={cn(
-        `mx-auto w-full flex-1 ${isHeader && 'mt-[100px]'} ${isMaxW && 'max-width-container'} ${px}`,
-        className,
-      )}
+      className={cn(`mx-auto w-full flex-1 ${isMaxW && 'max-width-container'} ${px}`, className)}
+      style={{ marginTop: `${isHeader ? HEADER_HEIGHT_SIZE : 0}px` }}
     >
       {children}
     </main>

--- a/src/components/header/AdminHeader.tsx
+++ b/src/components/header/AdminHeader.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import { Logo } from '@/assets/icon';
 import { HEADER_HEIGHT_SIZE } from '@/constants/common';
@@ -6,6 +6,8 @@ import { ADMIN_HEADER_ITEMS } from '@/constants/navigation';
 import { routePath } from '@/constants/path';
 
 const AdminHeader = () => {
+  const navigate = useNavigate();
+
   return (
     <header
       className='px-md flex w-full items-center border-b border-solid border-[#E2E2E2] bg-white'
@@ -28,14 +30,14 @@ const AdminHeader = () => {
           </div>
 
           {ADMIN_HEADER_ITEMS.map((item) => (
-            <Link
+            <button
               key={item.type}
-              to={item.path}
+              onClick={() => navigate(item.path)}
               className='relative flex flex-col items-center justify-center gap-1'
             >
               {item.icon}
               <span className='text-xs font-semibold'>{item.name}</span>
-            </Link>
+            </button>
           ))}
         </nav>
       </div>

--- a/src/components/header/AdminHeader.tsx
+++ b/src/components/header/AdminHeader.tsx
@@ -2,7 +2,7 @@ import { Link, useNavigate } from 'react-router-dom';
 
 import { Logo } from '@/assets/icon';
 import { HEADER_HEIGHT_SIZE } from '@/constants/common';
-import { ADMIN_HEADER_ITEMS } from '@/constants/navigation';
+import { ADMIN_HEADER_ITEMS } from '@/constants/header';
 import { routePath } from '@/constants/path';
 
 const AdminHeader = () => {

--- a/src/components/header/AdminHeader.tsx
+++ b/src/components/header/AdminHeader.tsx
@@ -1,40 +1,22 @@
-import { CiLogout, CiUser } from 'react-icons/ci';
 import { Link } from 'react-router-dom';
 
 import { Logo } from '@/assets/icon';
+import { HEADER_HEIGHT_SIZE } from '@/constants/common';
+import { ADMIN_HEADER_ITEMS } from '@/constants/navigation';
 import { routePath } from '@/constants/path';
 
-// TODO  기능 추가 필요/반응형 작업 필요
-const AdminHeader: React.FC = () => {
-  const ICON_SIZE = 25;
-
-  const adminHeaderItems = [
-    {
-      type: 'logout',
-      name: '로그아웃',
-      icon: <CiLogout size={ICON_SIZE} />,
-      path: '/',
-    },
-    {
-      type: 'user',
-      name: '사용자 전환',
-      icon: <CiUser size={ICON_SIZE} />,
-      path: '/',
-    },
-  ];
-
+const AdminHeader = () => {
   return (
-    <header className='px-md flex h-[100px] items-center border-b border-solid border-[#E2E2E2] bg-white'>
-      <div className='max-width-container mx-auto flex w-full items-center justify-between'>
+    <header
+      className='px-md flex w-full items-center border-b border-solid border-[#E2E2E2] bg-white'
+      style={{ height: `${HEADER_HEIGHT_SIZE}px` }}
+    >
+      <div className='mx-auto flex w-full items-center justify-between'>
         <h2 className='flex items-center gap-1'>
           <Link to={routePath.common.root} title='admin home'>
-            <img src={Logo} alt='logo' width={129} height={21} />
+            <img src={Logo} alt='logo' width={100} />
           </Link>
-          <Link
-            to={routePath.admin.management.subscribe}
-            title='admin home'
-            className='text-[30px]'
-          >
+          <Link to={routePath.admin.management.subscribe} title='admin home' className='text-xl'>
             Admin
           </Link>
         </h2>
@@ -45,7 +27,7 @@ const AdminHeader: React.FC = () => {
             <span className='font-bold'>홍길동님</span>
           </div>
 
-          {adminHeaderItems.map((item) => (
+          {ADMIN_HEADER_ITEMS.map((item) => (
             <Link
               key={item.type}
               to={item.path}

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,5 +1,5 @@
 import { CiMenuBurger } from 'react-icons/ci';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import Select from '../select/Select';
 
@@ -17,6 +17,7 @@ import useLocale from '@/hooks/useLocale';
 import useLoginedStore from '@/stores/loginedStore';
 
 const Header = () => {
+  const navigate = useNavigate();
   const { locale, changeLocale } = useLocale();
 
   const isLogined = useLoginedStore((state) => state.isLogined);
@@ -25,11 +26,9 @@ const Header = () => {
     ? [...LOGGEND_IN_ITEMS, ...HEADER_COMMON_ITEMS]
     : [...LOGGEND_OUT_ITEMS, ...HEADER_COMMON_ITEMS];
 
-  const onChangeLocale = (value: string) => {
-    if (value === 'ko' || value === 'en') {
-      changeLocale(value);
-      location.reload();
-    }
+  const onChangeLocale = () => {
+    changeLocale(locale === 'ko' ? 'en' : 'ko');
+    location.reload();
   };
 
   return (
@@ -49,7 +48,7 @@ const Header = () => {
           <nav className='gap-x-md hidden items-center md:flex'>
             <Select
               value={locale === 'ko' ? '한국어' : 'English'}
-              onChange={() => onChangeLocale(locale === 'ko' ? 'en' : 'ko')}
+              onChange={onChangeLocale}
               className='flex items-center justify-center gap-1 rounded-md py-1 text-sm font-semibold hover:bg-gray-50'
             >
               <Select.Trigger
@@ -71,36 +70,27 @@ const Header = () => {
               </Select.Content>
             </Select>
 
-            {headerItems.map((item) =>
-              item.type === 'logout' ? (
-                <button
-                  key={item.type}
-                  onClick={() => {
-                    if (typeof item.path === 'function') {
-                      item.path();
-                    }
-                  }}
-                  className='relative flex flex-col items-center justify-center gap-1'
-                >
-                  {item.icon}
-                  <span className='text-xs font-semibold'>{item.name}</span>
-                </button>
-              ) : (
-                <Link
-                  key={item.type}
-                  to={item.path as string}
-                  className='relative flex flex-col items-center justify-center gap-1'
-                >
-                  {item.type === 'cart' && (
-                    <span className='absolute -top-1 right-1 flex aspect-square h-4 w-4 items-center justify-center rounded-full bg-black text-[10px] text-white'>
-                      0
-                    </span>
-                  )}
-                  {item.icon}
-                  <span className='text-xs font-semibold'>{item.name}</span>
-                </Link>
-              ),
-            )}
+            {headerItems.map((item) => (
+              <button
+                key={item.type}
+                onClick={() => {
+                  if (typeof item.path === 'function' && item.type === 'logout') {
+                    item.path();
+                  } else {
+                    navigate(item.path as string);
+                  }
+                }}
+                className='relative flex flex-col items-center justify-center gap-1'
+              >
+                {item.type === 'cart' && (
+                  <span className='absolute -top-1 right-1 flex aspect-square h-4 w-4 items-center justify-center rounded-full bg-black text-[10px] text-white'>
+                    0
+                  </span>
+                )}
+                {item.icon}
+                <span className='text-xs font-semibold'>{item.name}</span>
+              </button>
+            ))}
           </nav>
         )}
       </div>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -10,8 +10,8 @@ import {
   LOGGEND_IN_ITEMS,
   HEADER_COMMON_ITEMS,
   LOGGEND_OUT_ITEMS,
-  NAVIGATION_ICON_SIZE,
-} from '@/constants/navigation';
+  HEADER_ICON_SIZE,
+} from '@/constants/header';
 import { routePath } from '@/constants/path';
 import useLocale from '@/hooks/useLocale';
 import useLoginedStore from '@/stores/loginedStore';
@@ -97,7 +97,7 @@ const Header = () => {
 
       {/* mo nav */}
       <button className='block md:hidden' onClick={() => console.log('show mobile nav')}>
-        <CiMenuBurger size={NAVIGATION_ICON_SIZE} />
+        <CiMenuBurger size={HEADER_ICON_SIZE} />
       </button>
     </header>
   );

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,90 +1,114 @@
-import { CiLogin, CiLogout, CiUser } from 'react-icons/ci';
-import { IoMdArrowDropdown } from 'react-icons/io';
-import { PiShoppingBagLight } from 'react-icons/pi';
+import { CiMenuBurger } from 'react-icons/ci';
 import { Link } from 'react-router-dom';
+
+import Select from '../select/Select';
 
 import { Logo } from '@/assets/icon';
 import IconLanguage from '@/assets/icon/IconLanguage';
+import { HEADER_HEIGHT_SIZE } from '@/constants/common';
+import {
+  LOGGEND_IN_ITEMS,
+  HEADER_COMMON_ITEMS,
+  LOGGEND_OUT_ITEMS,
+  NAVIGATION_ICON_SIZE,
+} from '@/constants/navigation';
 import { routePath } from '@/constants/path';
+import useLocale from '@/hooks/useLocale';
 import useLoginedStore from '@/stores/loginedStore';
 
-// TODO  기능 추가 필요/반응형 작업 필요
-const Header: React.FC = () => {
-  const ICON_SIZE = 25;
+const Header = () => {
+  const { locale, changeLocale } = useLocale();
+
   const isLogined = useLoginedStore((state) => state.isLogined);
 
-  const commonItems = [
-    {
-      type: 'cart',
-      name: '장바구니',
-      icon: <PiShoppingBagLight size={ICON_SIZE} />,
-      path: routePath.common.cart,
-    },
-  ];
-
-  const loggedOutItems = [
-    {
-      type: 'login',
-      name: '로그인',
-      icon: <CiLogin size={ICON_SIZE} />,
-      path: routePath.common.login,
-    },
-  ];
-
-  const loggedInItems = [
-    {
-      type: 'logout',
-      name: '로그아웃',
-      icon: <CiLogout size={ICON_SIZE} />,
-      path: '/',
-    },
-    {
-      type: 'user',
-      name: '내정보',
-      icon: <CiUser size={ICON_SIZE} />,
-      path: routePath.member.mypage,
-    },
-  ];
-
   const headerItems = isLogined
-    ? [...loggedInItems, ...commonItems]
-    : [...loggedOutItems, ...commonItems];
+    ? [...LOGGEND_IN_ITEMS, ...HEADER_COMMON_ITEMS]
+    : [...LOGGEND_OUT_ITEMS, ...HEADER_COMMON_ITEMS];
+
+  const onChangeLocale = (value: string) => {
+    if (value === 'ko' || value === 'en') {
+      changeLocale(value);
+      location.reload();
+    }
+  };
 
   return (
-    <header className='px-md fixed top-0 z-50 flex h-[100px] w-full items-center bg-white'>
+    <header
+      className='px-md fixed top-0 z-50 flex w-full items-center border-b border-solid border-[#E2E2E2] bg-white'
+      style={{ height: `${HEADER_HEIGHT_SIZE}px` }}
+    >
       <div className='max-width-container mx-auto flex w-full items-center justify-between'>
-        <Link to='/' title='home'>
+        <Link to={routePath.common.root} title='home'>
           <h2>
-            <img src={Logo} alt='logo' width={129} height={21} />
+            <img src={Logo} alt='logo' width={100} />
           </h2>
         </Link>
 
-        {isLogined !== null ? (
-          <nav className='gap-x-md flex items-center'>
-            <button className='flex items-center justify-center gap-1'>
-              <IconLanguage size='20' />
-              <span className='text-sm font-semibold'>한국어</span>
-              <IoMdArrowDropdown />
-            </button>
+        {/* pc nav */}
+        {isLogined !== null && (
+          <nav className='gap-x-md hidden items-center md:flex'>
+            <Select
+              value={locale === 'ko' ? '한국어' : 'English'}
+              onChange={() => onChangeLocale(locale === 'ko' ? 'en' : 'ko')}
+              className='flex items-center justify-center gap-1 rounded-md py-1 text-sm font-semibold hover:bg-gray-50'
+            >
+              <Select.Trigger
+                className='gap-3'
+                placeholder={locale === 'ko' ? '한국어' : 'English'}
+                icon={<IconLanguage size='20' />}
+                iconPosition='left'
+              />
 
-            {headerItems.map((item) => (
-              <Link
-                key={item.type}
-                to={item.path as string}
-                className='relative flex flex-col items-center justify-center gap-1'
-              >
-                {item.type === 'cart' && (
-                  <span className='absolute -top-1 right-1 flex aspect-square h-4 w-4 items-center justify-center rounded-full bg-black text-[10px] text-white'>
-                    0
-                  </span>
-                )}
-                {item.icon}
-                <span className='text-xs font-semibold'>{item.name}</span>
-              </Link>
-            ))}
+              <Select.Content className='border-1 border-[#DEDEDE]'>
+                <Select.Group className='grid'>
+                  <Select.Item
+                    value={locale === 'ko' ? 'en' : 'ko'}
+                    className='text-sm font-semibold hover:bg-gray-100'
+                  >
+                    {locale === 'ko' ? 'English' : '한국어'}
+                  </Select.Item>
+                </Select.Group>
+              </Select.Content>
+            </Select>
+
+            {headerItems.map((item) =>
+              item.type === 'logout' ? (
+                <button
+                  key={item.type}
+                  onClick={() => {
+                    if (typeof item.path === 'function') {
+                      item.path();
+                    }
+                  }}
+                  className='relative flex flex-col items-center justify-center gap-1'
+                >
+                  {item.icon}
+                  <span className='text-xs font-semibold'>{item.name}</span>
+                </button>
+              ) : (
+                <Link
+                  key={item.type}
+                  to={item.path as string}
+                  className='relative flex flex-col items-center justify-center gap-1'
+                >
+                  {item.type === 'cart' && (
+                    <span className='absolute -top-1 right-1 flex aspect-square h-4 w-4 items-center justify-center rounded-full bg-black text-[10px] text-white'>
+                      0
+                    </span>
+                  )}
+                  {item.icon}
+                  <span className='text-xs font-semibold'>{item.name}</span>
+                </Link>
+              ),
+            )}
           </nav>
-        ) : null}
+        )}
       </div>
+
+      {/* mo nav */}
+      <button className='block md:hidden' onClick={() => console.log('show mobile nav')}>
+        <CiMenuBurger size={NAVIGATION_ICON_SIZE} />
+      </button>
     </header>
   );
 };

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -1,1 +1,3 @@
 export const ADMIN_SELECT_ITEMS = [10, 20, 30];
+
+export const HEADER_HEIGHT_SIZE = 80;

--- a/src/constants/header.tsx
+++ b/src/constants/header.tsx
@@ -6,13 +6,13 @@ import { routePath } from './path';
 
 import { resetToken } from '@/utils/auth/authToken';
 
-export const NAVIGATION_ICON_SIZE = 25;
+export const HEADER_ICON_SIZE = 25;
 
 export const HEADER_COMMON_ITEMS = [
   {
     type: 'cart',
     name: '장바구니',
-    icon: <PiShoppingBagLight size={NAVIGATION_ICON_SIZE} />,
+    icon: <PiShoppingBagLight size={HEADER_ICON_SIZE} />,
     path: routePath.common.cart,
   },
 ];
@@ -21,7 +21,7 @@ export const LOGGEND_OUT_ITEMS = [
   {
     type: 'login',
     name: '로그인',
-    icon: <CiLogin size={NAVIGATION_ICON_SIZE} />,
+    icon: <CiLogin size={HEADER_ICON_SIZE} />,
     path: routePath.common.login,
   },
 ];
@@ -30,7 +30,7 @@ export const LOGGEND_IN_ITEMS = [
   {
     type: 'logout',
     name: '로그아웃',
-    icon: <CiLogout size={NAVIGATION_ICON_SIZE} />,
+    icon: <CiLogout size={HEADER_ICON_SIZE} />,
     path: () => {
       resetToken();
       redirect('/');
@@ -39,7 +39,7 @@ export const LOGGEND_IN_ITEMS = [
   {
     type: 'user',
     name: '내정보',
-    icon: <CiUser size={NAVIGATION_ICON_SIZE} />,
+    icon: <CiUser size={HEADER_ICON_SIZE} />,
     path: routePath.member.mypage.root,
   },
 ];
@@ -48,13 +48,13 @@ export const ADMIN_HEADER_ITEMS = [
   {
     type: 'logout',
     name: '로그아웃',
-    icon: <CiLogout size={NAVIGATION_ICON_SIZE} />,
+    icon: <CiLogout size={HEADER_ICON_SIZE} />,
     path: '/',
   },
   {
     type: 'user',
     name: '사용자 전환',
-    icon: <CiUser size={NAVIGATION_ICON_SIZE} />,
+    icon: <CiUser size={HEADER_ICON_SIZE} />,
     path: '/',
   },
 ];

--- a/src/constants/navigation.tsx
+++ b/src/constants/navigation.tsx
@@ -1,0 +1,60 @@
+import { CiLogin, CiLogout, CiUser } from 'react-icons/ci';
+import { PiShoppingBagLight } from 'react-icons/pi';
+import { redirect } from 'react-router-dom';
+
+import { routePath } from './path';
+
+import { resetToken } from '@/utils/auth/authToken';
+
+export const NAVIGATION_ICON_SIZE = 25;
+
+export const HEADER_COMMON_ITEMS = [
+  {
+    type: 'cart',
+    name: '장바구니',
+    icon: <PiShoppingBagLight size={NAVIGATION_ICON_SIZE} />,
+    path: routePath.common.cart,
+  },
+];
+
+export const LOGGEND_OUT_ITEMS = [
+  {
+    type: 'login',
+    name: '로그인',
+    icon: <CiLogin size={NAVIGATION_ICON_SIZE} />,
+    path: routePath.common.login,
+  },
+];
+
+export const LOGGEND_IN_ITEMS = [
+  {
+    type: 'logout',
+    name: '로그아웃',
+    icon: <CiLogout size={NAVIGATION_ICON_SIZE} />,
+    path: () => {
+      resetToken();
+      redirect('/');
+    },
+  },
+  {
+    type: 'user',
+    name: '내정보',
+    icon: <CiUser size={NAVIGATION_ICON_SIZE} />,
+    path: routePath.member.mypage,
+  },
+];
+
+export const ADMIN_HEADER_ITEMS = [
+  {
+    type: 'logout',
+    name: '로그아웃',
+    icon: <CiLogout size={NAVIGATION_ICON_SIZE} />,
+    path: '/',
+  },
+  {
+    type: 'user',
+    name: '사용자 전환',
+    icon: <CiUser size={NAVIGATION_ICON_SIZE} />,
+    path: '/',
+  },
+];

--- a/src/constants/navigation.tsx
+++ b/src/constants/navigation.tsx
@@ -40,7 +40,7 @@ export const LOGGEND_IN_ITEMS = [
     type: 'user',
     name: '내정보',
     icon: <CiUser size={NAVIGATION_ICON_SIZE} />,
-    path: routePath.member.mypage,
+    path: routePath.member.mypage.root,
   },
 ];
 

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -5,7 +5,7 @@ import { CATEGORY_COLORS } from '@/constants/colors';
 
 export const getCategoryColor = (categoryName: string): string => {
   let hash = 0;
-  for (let i = 0; i < categoryName.length; i++) {
+  for (let i = 0; i < categoryName?.length; i++) {
     const char = categoryName.charCodeAt(i);
     hash = (hash << 5) - hash + char;
     hash = hash & hash;


### PR DESCRIPTION
## PR 타입

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [x] 기타

## 반영 브랜치

<!-- 예: feature/login → develop -->

`HP-167` → `dev`

## 작업 사항

- common) 
  - header 높이 수정 (상수로 관리)
  - LayoutContainer margin-top 사이즈 조절
- member) 
  - 언어 설정 기능 추가
  - 1차 반응형 작업 (모바일 nav 작업 필요함)
- admin)
  - max-w 스타일 제거

 [기타]
- 다른 페이지에서 로고 클릭 후 넘어갈 경우 categoryName.length가 undefined일 수도 있다고 하여 옵셔널 추가했습니다.
 [Fix: categoryName.length 옵셔널 추가](https://github.com/happy-pill/happyPill_Front/commit/d54631f7f244819d9fcda809e3de936b316abccd)

## 공유사항
- 메인 페이지, 상품 상세페이지 header 사이즈 조절로 인해 container margin-top, tabmenu top 사이즈 조절이 필요합니다.
- SelectBox 아이콘이 하나만 추가 할 수 있어 추후 코드 수정이 필요할 것 같습니다.
- 언어 설정은 추후 모바일 navigation 추가할 때 같이 수정하겠습니다.

## 체크리스트

- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (예: `cmd + opt + L`)

## 테스트 결과

<img width="1417" height="117" alt="스크린샷 2025-07-30 오후 6 53 49" src="https://github.com/user-attachments/assets/9e34c870-4d8f-421f-8439-e6c84aec1576" />

<img width="1416" height="656" alt="스크린샷 2025-07-30 오후 6 54 45" src="https://github.com/user-attachments/assets/6885d2e6-4c70-4502-9a25-33b885135047" />

