### PR TITLE
Fix: 백엔드 데이터에 맞게 name필드명을 productName로 수정

### DIFF
--- a/src/pages/cart/components/molecules/CartItemCard.tsx
+++ b/src/pages/cart/components/molecules/CartItemCard.tsx
@@ -36,7 +36,11 @@ const CartItemCard = ({
       />
 
       <div className='grid grid-cols-[max-content_auto_30px] items-center gap-x-[clamp(8px,2vw,20px)]'>
-        <ProductThumbnail productId={item.productId} src={item.thumbnailUrl} alt={item.name} />
+        <ProductThumbnail
+          productId={item.productId}
+          src={item.thumbnailUrl}
+          alt={item.productName}
+        />
         <div className='grid grid-cols-[1fr_auto] items-center gap-x-[clamp(8px,2vw,20px)]'>
           <div className='grid items-center gap-x-[clamp(10px,2vw,20px)] gap-y-2 lg:grid-cols-[1fr_1fr] lg:justify-between'>
             <ProductInfo productName={item.productName} briefDescription={item.briefDescription} />

--- a/src/pages/cart/components/molecules/CartItemCard.tsx
+++ b/src/pages/cart/components/molecules/CartItemCard.tsx
@@ -39,7 +39,7 @@ const CartItemCard = ({
         <ProductThumbnail productId={item.productId} src={item.thumbnailUrl} alt={item.name} />
         <div className='grid grid-cols-[1fr_auto] items-center gap-x-[clamp(8px,2vw,20px)]'>
           <div className='grid items-center gap-x-[clamp(10px,2vw,20px)] gap-y-2 lg:grid-cols-[1fr_1fr] lg:justify-between'>
-            <ProductInfo productName={item.name} briefDescription={item.briefDescription} />
+            <ProductInfo productName={item.productName} briefDescription={item.briefDescription} />
             <PeriodSelector
               period={item.period}
               onChange={(value: string | number) => onPeriodChange(item.productId, Number(value))}

--- a/src/pages/product/components/atoms/ProductHeader.tsx
+++ b/src/pages/product/components/atoms/ProductHeader.tsx
@@ -18,7 +18,7 @@ const ProductHeader = ({ product }: ProductHeaderProps) => {
           <strong className='ml-1'>{PRODUCT_DELIVERY_BADGE[locale].highlight}</strong>
         </p>
       </div>
-      <h2 className='mt-1 mb-2 text-[clamp(20px,2vw,34px)] font-bold'>{product?.name}</h2>
+      <h2 className='mt-1 mb-2 text-[clamp(20px,2vw,34px)] font-bold'>{product?.productName}</h2>
       <p className='text-[clamp(10px,1.8vw,16px)] font-medium'> {product?.briefDescription}</p>
     </div>
   );

--- a/src/pages/product/components/molecules/ProductInfoSection.tsx
+++ b/src/pages/product/components/molecules/ProductInfoSection.tsx
@@ -52,7 +52,7 @@ const ProductInfoSection: React.FC<productInfoProps> = ({
 
   return (
     <div className='grid w-full grid-cols-1 gap-x-5 md:grid-cols-2'>
-      <ProductThumbnail src={product?.thumbnailUrl} alt={product?.name} />
+      <ProductThumbnail src={product?.thumbnailUrl} alt={product?.productName} />
       <div className='pt-5 md:p-8'>
         <ProductHeader product={product} />
 

--- a/src/pages/product/components/organisms/ProductDetailTabs.tsx
+++ b/src/pages/product/components/organisms/ProductDetailTabs.tsx
@@ -29,7 +29,7 @@ const ProductDetailTabs = ({
 }: ProductDetailTabsProps) => {
   const { locale } = useLocale();
   const PRODUCT_DETAIL_FIELDS = [
-    { label: PRODUCT_DETAIL[locale].name, value: product.name },
+    { label: PRODUCT_DETAIL[locale].name, value: product.productName },
     { label: PRODUCT_DETAIL[locale].quantityDetails, value: product.quantityDetails },
     { label: PRODUCT_DETAIL[locale].company, value: product.company },
     { label: PRODUCT_DETAIL[locale].usage, value: product.usage },

--- a/src/pages/product/index.tsx
+++ b/src/pages/product/index.tsx
@@ -15,6 +15,7 @@ import useCheckoutStore from '@/stores/checkoutStore';
 
 const ProductPage: React.FC = () => {
   const { productId } = useParams();
+
   const [subscriptionOption, setSubscriptionOption] = useState(1);
 
   const navigate = useNavigate();
@@ -26,11 +27,11 @@ const ProductPage: React.FC = () => {
   const { data: bestProductData, isLoading: isLoadingRelatedProducts } = useGetRelatedProducts();
 
   const item = {
-    productId: productData.productId,
-    productName: productData.name,
-    price: productData.price,
-    briefDescription: productData.briefDescription,
-    thumbnailUrl: productData.thumbnailUrl,
+    productId: productData?.productId,
+    productName: productData?.name,
+    price: productData?.price,
+    briefDescription: productData?.briefDescription,
+    thumbnailUrl: productData?.thumbnailUrl,
     period: subscriptionOption,
   };
 


### PR DESCRIPTION
## PR 타입

- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 반영 브랜치

HP-175 → dev

## 작업 사항

-  상품 및 장바구니 페이지에서 사용되는 컴포넌트에 product 타입에 관련하여 name필드를 productName으로 수정했습니다.
-  빌드 오류에 대해 이 문제를 확인하고 수정했습니다.

## 체크리스트

- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (예: `cmd + opt + L`)

## 테스트 결과

- 테스트 결과 이상 없습니다.
 
